### PR TITLE
Update site_path handling in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,8 +4,18 @@ var request = require("request");
 module.exports = function(grunt) {
   'use strict';
 
-  // this is the directory path to your project on the stage/prod servers
-  var site_path = "single-page-project";
+  // This is the slug title of the project
+  // For example, "single-page-project"
+  var slug = "";
+
+  // This is the projects folder where the project will be deployed
+  // For example:
+  //     Enter "news" for http://projects.statesman.com/news
+  //     Enter "sports" for http://projects.statesman.com/sports
+  var projectsDirectory = "";
+
+  // This is the directory path to your project on the stage/prod servers
+  var site_path = projectsDirectory + "/" + slug;
 
   // Project configuration.
   grunt.initConfig({
@@ -101,7 +111,7 @@ module.exports = function(grunt) {
           authKey: 'cmg'
         },
         src: 'public',
-        dest: '/stage_aas/projects/single-page-project',
+        dest: '/stage_aas/projects/' + site_path,
         exclusions: ['dist/tmp','Thumbs.db','.DS_Store'],
         simple: false,
         useList: false
@@ -114,7 +124,7 @@ module.exports = function(grunt) {
           authKey: 'cmg'
         },
         src: 'public',
-        dest: '/stage_aas/projects/single-page-project-prod/',
+        dest: '/stage_aas/projects/' + site_path,
         exclusions: ['dist/tmp','Thumbs.db','.DS_Store'],
         simple: false,
         useList: false
@@ -136,11 +146,11 @@ module.exports = function(grunt) {
           var done = this.async();
 
           // prod or stage?
-          var ftp_path = where_dis_go === "prod" ? "http://projects.statesman.com/news/" + site_path : "http://stage.host.coxmediagroup.com/aas/projects/news/" + site_path;
+          var ftp_path = where_dis_go === "prod" ? "http://projects.statesman.com/" + site_path : "http://stage.host.coxmediagroup.com/aas/projects/" + site_path;
 
           // do whatever makes you feel happy here
           var payload = {
-              "text": "yo dawg i heard you like pushing code to *"+site_path+"*: " + ftp_path,
+              "text": "yo dawg i heard you like pushing code to *" + slug + "*: " + ftp_path,
               "channel": "#bakery",
               "username": "Xzibit",
               "icon_url": "http://projects.statesman.com/slack/icon_img/xzibit.jpg"

--- a/README.md
+++ b/README.md
@@ -5,18 +5,20 @@ Framework for a single page project, though it could be multiple pages. Just les
 
 ## Steps when you set up a project
 
-* use `package.json` and `npm install`
+* Use `package.json` and run `npm install`
 * You need the `.ftppass` and `.slack` files described below.
-* Run the default grunt task.
+* Update the `slug` and `projectsDirectory` variables in `Gruntfile.js`.
+* Update the `thumbnail` and `url` variables at the top of `index.php`.
+* Run the default `grunt` task.
 
 (At one point we used bower to pull in font-awesome, bootstrap and jquery, but these are now pulled in through npm.)
 
 ### Public folder
 There is a `public` folder that has the published files:
-	* assets: images and other accces
-	* dist: where js and css is compiled
-	* fonts: for font-awesome
-	* includes: files for metrics, advertising and other includes
+* assets: images and other accces
+* dist: where js and css is compiled
+* fonts: for font-awesome
+* includes: files for metrics, advertising and other includes
 
 ### Src folder
 The `src` folder is for components that are used by grunt tasks and copied into the `public/dist` folder:

--- a/public/index.php
+++ b/public/index.php
@@ -7,10 +7,10 @@
   $meta = array(
     "title" => "Single page project | Statesman.com",
     "description" => "Description for single-page-project.",
-    "thumbnail" => "http://projects.statesman.com/project_path/assets/share.png", // needs update
+    "thumbnail" => "http://projects.statesman.com/site_path/assets/share.png", // needs update
     "shortcut_icon" => "http://media.cmgdigital.com/shared/media/2015-11-16-11-32-05/web/site/www_mystatesman_com/images/favicon.ico",
     "apple_touch_icon" => "http://media.cmgdigital.com/shared/theme-assets/242014/www.statesman.com_fa2d2d6e73614535b997734c7e7d2287.png",
-    "url" => "http://projects.statesman.com/project_path/",
+    "url" => "http://projects.statesman.com/site_path/", // needs update
     "twitter" => "statesman"
   );
 ?>

--- a/public/index.php
+++ b/public/index.php
@@ -7,7 +7,7 @@
   $meta = array(
     "title" => "Single page project | Statesman.com",
     "description" => "Description for single-page-project.",
-    "thumbnail" => "http://projects.statesman.com/site_path/assets/share.png", // needs update
+    "thumbnail" => "http://projects.statesman.com/site_path/assets/share.jpg", // needs update
     "shortcut_icon" => "http://media.cmgdigital.com/shared/media/2015-11-16-11-32-05/web/site/www_mystatesman_com/images/favicon.ico",
     "apple_touch_icon" => "http://media.cmgdigital.com/shared/theme-assets/242014/www.statesman.com_fa2d2d6e73614535b997734c7e7d2287.png",
     "url" => "http://projects.statesman.com/site_path/", // needs update


### PR DESCRIPTION
This tweaks how the user sets the project `site_path` for stage and prod by:
- forcing the user to set `projectsDirectory` and `slug` variables in `Gruntfile.js`
- renaming the placer holder string in `index.php` so it matches what's in `Gruntfile.js`

There are also some tweaks to the readme and the default share image path.
### How to test this

use this code to `grunt stage` an old single page project, check that it deploys to stage cleanly
### Further todo
- Can the `Gruntfile.js` path variables automatically set paths in `index.php`?
